### PR TITLE
Portal Gem Consumption and Error Handling

### DIFF
--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -196,7 +196,16 @@ namespace ACE.Server.WorldObjects
                 // omitting the item caster here, so player is also used for enchantment registry caster,
                 // which could prevent some scenarios with spamming enchantments from multiple gem sources to protect against dispels
 
-                // TODO: figure this out better
+                if ((spell.Id == 1635 && player.LinkedLifestone == null) ||
+                    (spell.Id == 48 && player.LinkedPortalOneDID == null) ||
+                    (spell.Id == 2647 && player.LinkedPortalTwoDID == null))
+                {
+                    //player.Session.Network.EnqueueSend(new GameMessageSystemChat($"No linked destination!", ChatMessageType.Broadcast));
+                    player.SendTransientError("No linked destination!");
+                    return;
+                }
+
+                    // TODO: figure this out better
                 if (spell.MetaSpellType == SpellType.PortalSummon && (LinkedPortalOneDID != null || LinkedPortalTwoDID != null)) // if we're a summon portal gem and we have a linked portal use that, otherwise use the player's.
                     TryCastSpell(spell, player, this, tryResist: false);
                 else if (spell.IsImpenBaneType || spell.IsItemRedirectableType)
@@ -339,8 +348,8 @@ namespace ACE.Server.WorldObjects
             {
                 if (!resultTarget.Success)
                 {
-                    if (result.Message != null)
-                        player.Session.Network.EnqueueSend(result.Message);
+                    if (resultTarget.Message != null)
+                        player.Session.Network.EnqueueSend(resultTarget.Message);
                     player.SendUseDoneEvent();
                     return;
                 }


### PR DESCRIPTION
Do not consume a Lifestone or Portal Recall gem if there is no linked destination.

Do still punish the player for being a dork by running the animation and invoking the timer.

Also, if an item is used on a target and the result is not successful (e.g. try to use a portal tie on a portal you cannot use, such as an outpost portal), then return the appropriate error message for that target. Previously, it was attempting to return the wrong (result) error, rather than the target item (resultTarget) message. For some reason I don't immediately see, it also left the client in waiting mode, which required a client restart to resolve.