### PR TITLE
Re-Enable unarmed Unarmed Combat

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -389,17 +389,8 @@ namespace ACE.Server.WorldObjects
                         return;
                     }
 
-                    if (weapon == null)
-                    {
-                        // Handle the case where 'weapon' is null
-					    return;
-					}
-
-                    if (creature.Warded && creature.TogglePhys)
-                    {
-                        Session.Network.EnqueueSend(new GameMessageSystemChat($"{creature.Name} resists your attack completely", ChatMessageType.CombatEnemy));
-                        return;
-                    }
+                    // If weapon==null, then this is unarmed combat, which is accounted in DamageTarget
+                    // check for this explicitly in any custom behaviors below.
 
                     //if (Common.ConfigManager.Config.Server.WorldRuleset == Common.Ruleset.CustomDM && !IsDirectVisible(target))
                     //{
@@ -430,7 +421,7 @@ namespace ACE.Server.WorldObjects
                         }
                     }
                     
-                    if (weapon.IsPiercing)
+                    if (weapon != null && weapon.IsPiercing)
                     {
                         var pierce = GetPierceTarget(creature, weapon);
 


### PR DESCRIPTION
A null weapon is valid for unarmed combat, which is accounted in DamageTarget check for this explicitly in any custom behaviors.

This allows bare-hand/foot fighting with glove/boot damage or default if none. This gives a new UA a way to kill the first golem to get to training cestus.